### PR TITLE
Remove unnecessary rate limiter

### DIFF
--- a/backend/generate_encryption_key.py
+++ b/backend/generate_encryption_key.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""
+Generate a secure encryption key for the Flask application.
+Run this script and set the output as the ENCRYPTION_KEY environment variable.
+"""
+
+from cryptography.fernet import Fernet
+
+def generate_encryption_key():
+    """Generate a new encryption key for Fernet encryption."""
+    key = Fernet.generate_key()
+    return key.decode()
+
+if __name__ == "__main__":
+    key = generate_encryption_key()
+    print("Generated encryption key:")
+    print(key)
+    print("\nTo use this key, set it as an environment variable:")
+    print(f"export ENCRYPTION_KEY='{key}'")
+    print("\nOr add it to your .env file:")
+    print(f"ENCRYPTION_KEY={key}")


### PR DESCRIPTION
Disable rate limiting by default to resolve worker process errors and provide clear guidance for setting the encryption key.

The `Limiter.__init__()` error was due to a parameter conflict when Redis was unavailable, leading to the worker process error. Rate limiting is now disabled by default, aligning with the explicit requirement that it's not needed, while still allowing it to be enabled via an environment variable.