### PR TITLE
Fix anthropic httpx version conflict

### DIFF
--- a/anthropic_httpx_compatibility_fix.md
+++ b/anthropic_httpx_compatibility_fix.md
@@ -1,0 +1,120 @@
+# Anthropic Library Version Conflict Fix
+
+## Problem Analysis
+
+The error `TypeError: Client.__init__() got an unexpected keyword argument 'proxies'` occurs due to a version incompatibility between the `anthropic` library (version 0.34.1) and the `httpx` library dependency.
+
+### Root Cause
+- **httpx version 0.28.0** (released November 28, 2024) removed the deprecated `proxies` parameter
+- The `anthropic` library version 0.34.1 still uses the old `proxies` parameter when initializing the httpx client
+- This creates a breaking change when Render or other deployment platforms install the latest httpx version
+
+### Current Configuration
+From your `backend/requirements.txt`:
+```
+anthropic==0.34.1
+```
+
+Your `backend/application.py` usage:
+```python
+claude_client = anthropic.Anthropic(api_key=claude_api_key)
+```
+
+## Solution Options
+
+### Option 1: Pin httpx Version (Quick Fix)
+Add to your `requirements.txt`:
+```
+httpx==0.27.2
+```
+
+This pins httpx to a version that still supports the `proxies` parameter.
+
+### Option 2: Upgrade Anthropic Library (Recommended)
+Update your `requirements.txt`:
+```
+anthropic>=0.42.0
+```
+
+Newer versions of the anthropic library (0.42.0+) are compatible with httpx 0.28.0+.
+
+### Option 3: Hybrid Approach (Most Stable)
+```
+anthropic>=0.42.0
+httpx>=0.27.2,<0.29.0
+```
+
+This ensures compatibility while allowing some flexibility in httpx versions.
+
+## Implementation Steps
+
+### For Render Deployment:
+
+1. **Update requirements.txt** with one of the solutions above
+2. **Redeploy** the application to Render
+3. **Monitor logs** to ensure successful deployment
+
+### For Local Development:
+
+1. **Update requirements.txt**
+2. **Reinstall dependencies**:
+   ```bash
+   pip install -r requirements.txt --upgrade
+   ```
+3. **Test the application** locally before deploying
+
+## Verification
+
+After implementing the fix, verify the solution works by:
+
+1. **Check that the anthropic client initializes properly**:
+   ```python
+   import anthropic
+   client = anthropic.Anthropic(api_key="test-key")
+   print("Client initialized successfully")
+   ```
+
+2. **Review deployment logs** for any remaining errors
+
+3. **Test API endpoints** that use the Claude client
+
+## Prevention
+
+To prevent similar issues in the future:
+
+1. **Pin major dependencies** in production environments
+2. **Use dependency lock files** (e.g., `requirements-lock.txt`)
+3. **Monitor dependency security advisories**
+4. **Test upgrades** in staging before production
+
+## Technical Details
+
+### Why This Happened
+- The `httpx` library removed the `proxies` parameter in favor of a new proxy configuration system
+- The `anthropic` library was passing proxy configuration using the old `proxies` parameter
+- When Render installed the latest packages, it pulled httpx 0.28.0, breaking the anthropic library
+
+### Library Compatibility Matrix
+| anthropic | httpx | Compatible |
+|-----------|-------|------------|
+| 0.34.1    | 0.27.2| ✅ Yes     |
+| 0.34.1    | 0.28.0| ❌ No      |
+| 0.42.0+   | 0.27.2| ✅ Yes     |
+| 0.42.0+   | 0.28.0| ✅ Yes     |
+
+## Recommended Solution
+
+For your production environment, I recommend **Option 2** (upgrading anthropic) because:
+
+1. **Future-proof**: Uses the latest anthropic library with bug fixes and improvements
+2. **Security**: Newer versions typically include security patches
+3. **Compatibility**: Properly supports the latest httpx versions
+4. **Maintenance**: Reduces technical debt
+
+Update your `backend/requirements.txt`:
+```diff
+- anthropic==0.34.1
++ anthropic>=0.42.0
+```
+
+Then redeploy to Render. This should resolve the error while keeping your application up-to-date with the latest improvements.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ bcrypt==4.1.2
 pyjwt==2.8.0
 flask-limiter==3.5.0
 stripe==7.7.0
-anthropic==0.34.1
+anthropic>=0.42.0
 cryptography>=41.0.8
 flask-mail==0.9.1
 APScheduler==3.10.4


### PR DESCRIPTION
Update anthropic library version to resolve `TypeError` due to `httpx` incompatibility.

This fixes a `TypeError: Client.__init__() got an unexpected keyword argument 'proxies'` which occurred because `anthropic==0.34.1` was incompatible with `httpx==0.28.0+`. The `httpx` library removed the deprecated `proxies` parameter, which `anthropic==0.34.1` was still using. Upgrading `anthropic` to `>=0.42.0` resolves this by using the new proxy configuration.