### PR TITLE
Fix Flask before_first_request error

### DIFF
--- a/backend/application.py
+++ b/backend/application.py
@@ -1317,11 +1317,7 @@ def init_db():
     except Exception as e:
         logging.error(f"Error creating database tables: {e}")
 
-# Initialize database when the app starts
-@application.before_first_request
-def create_tables():
-    """Create database tables before first request"""
-    init_db()
+# Database initialization is handled by initialize_database() function above
 
 # CLI command for manual database creation
 @application.cli.command('create-db')

--- a/flask_before_first_request_fix.md
+++ b/flask_before_first_request_fix.md
@@ -1,0 +1,79 @@
+# Flask before_first_request Fix
+
+## Problem
+The Flask application was failing to start with the error:
+```
+AttributeError: 'Flask' object has no attribute 'before_first_request'
+```
+
+This error occurs because the `@app.before_first_request` decorator was deprecated in Flask 2.2 and completely removed in Flask 3.0.
+
+## Root Cause
+The application was using the deprecated `@application.before_first_request` decorator to initialize database tables before the first request was processed:
+
+```python
+@application.before_first_request
+def create_tables():
+    """Create database tables before first request"""
+    init_db()
+```
+
+## Solution Applied
+The deprecated decorator and function have been removed and replaced with the existing modern database initialization approach:
+
+### Changes Made:
+1. **Removed deprecated decorator**: Eliminated the `@application.before_first_request` decorator usage
+2. **Removed redundant function**: Removed the `create_tables()` function as it was redundant
+3. **Leveraged existing solution**: The application already had a proper `initialize_database()` function that:
+   - Uses the modern Flask application context approach
+   - Includes robust error handling and retry logic
+   - Is called during application startup (after model definitions)
+
+### The Modern Approach:
+```python
+def initialize_database():
+    """
+    Initialize database with proper error handling and retries.
+    """
+    max_retries = 3
+    retry_delay = 2
+    
+    for attempt in range(max_retries):
+        try:
+            with application.app_context():
+                # Test database connection first
+                with db.engine.connect() as connection:
+                    connection.execute(db.text("SELECT 1"))
+                logging.info("Database connection successful!")
+                
+                # Create all tables if they don't exist
+                db.create_all()
+                logging.info("Database tables checked/created successfully!")
+                return True
+                
+        except Exception as e:
+            # Error handling and retry logic...
+            
+# Called during app startup
+initialize_database()
+```
+
+## Benefits of the Fix
+1. **Flask 3.0+ Compatibility**: The application now works with modern Flask versions
+2. **Better Error Handling**: The new approach includes comprehensive error handling and retry logic
+3. **More Robust**: Database initialization happens immediately on startup rather than waiting for the first request
+4. **Cleaner Code**: Removed redundant code and leveraged existing, better implementation
+
+## Verification
+The fix has been tested and verified to:
+- ✅ Remove all usage of deprecated `before_first_request`
+- ✅ Maintain proper database initialization functionality
+- ✅ Work with Flask 3.0+ requirements
+
+## Migration Notes
+If you encounter similar issues in other Flask applications:
+
+1. Replace `@app.before_first_request` with application startup initialization
+2. Use `with app.app_context():` for database operations
+3. Consider adding error handling and retry logic for production robustness
+4. Call initialization functions after all models are defined but before the app starts serving requests


### PR DESCRIPTION
Remove deprecated Flask `before_first_request` decorator to resolve `AttributeError` and leverage existing robust database initialization.

The `before_first_request` decorator was removed in Flask 3.0+, causing an `AttributeError` during application startup. This PR replaces its usage with the already present `initialize_database()` function, which offers a more modern, robust, and compatible way to set up the database.