### PR TITLE
Fix unused react import error

### DIFF
--- a/manager-dashboard-tauri/src/pages/Billing.tsx
+++ b/manager-dashboard-tauri/src/pages/Billing.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { CreditCard, Users, AlertTriangle, CheckCircle, Clock } from 'lucide-react';
 
 interface SubscriptionData {


### PR DESCRIPTION
Remove unused `React` import to resolve TS6133 error.

The `React` import is no longer required for JSX components in modern React (v17+) due to the new JSX transform.