### PR TITLE
Fix redis connection refused error

### DIFF
--- a/REDIS_FIX_INSTRUCTIONS.md
+++ b/REDIS_FIX_INSTRUCTIONS.md
@@ -1,0 +1,89 @@
+# Redis Connection Fix for ProductivityFlow
+
+## Problem
+Your Flask application is failing because it's trying to connect to Redis at `localhost:6379` for rate limiting, but no Redis instance is available on Render.
+
+## Quick Fix (Immediate Solution)
+
+I've already updated your `backend/application.py` to properly handle Redis connection failures. The application will now:
+
+1. Try to connect to Redis first
+2. If Redis is not available, fall back to in-memory rate limiting
+3. Continue working without crashing
+
+**This fix is already applied and should resolve your immediate issue.**
+
+## Proper Production Solution
+
+For a production application, you should set up a proper Redis instance:
+
+### Option 1: Using render.yaml (Recommended)
+
+I've created a `render.yaml` file that will set up:
+- A Redis Key Value instance for rate limiting
+- Proper environment variable linking
+
+To deploy with this:
+
+1. Commit the `render.yaml` file to your repository
+2. In your Render dashboard, create a new "Blueprint" instead of individual services
+3. Connect it to your repository and let Render set up both the web service and Redis instance
+
+### Option 2: Manual Setup
+
+If you prefer manual setup:
+
+1. **Create Redis Instance:**
+   - Go to Render Dashboard
+   - Click "New" → "Key Value"
+   - Name it `productivityflow-redis`
+   - Choose the same region as your web service
+   - Set max memory policy to `allkeys-lru`
+   - Click "Create Key Value"
+
+2. **Update Web Service Environment Variables:**
+   - Go to your web service in the Render dashboard
+   - Go to "Environment" tab
+   - Add environment variable:
+     - Key: `REDIS_URL`
+     - Value: Copy the "Internal Redis URL" from your Redis instance
+
+3. **Redeploy:**
+   - Your web service will automatically redeploy with the new environment variable
+
+## Benefits of Using Redis
+
+- **Shared rate limiting** across multiple server instances
+- **Persistent rate limiting** that survives deployments
+- **Better performance** for high-traffic applications
+- **Future-ready** for caching and session storage
+
+## Environment Variables Needed
+
+Make sure these environment variables are set in your Render web service:
+
+```
+REDIS_URL=redis://your-redis-instance:6379
+ENABLE_RATE_LIMITING=true
+SECRET_KEY=your-secret-key
+JWT_SECRET_KEY=your-jwt-secret
+ENCRYPTION_KEY=your-encryption-key
+```
+
+## Testing
+
+After implementing either solution:
+
+1. Check your application logs for: `Rate limiting configured with Redis` or `Rate limiting enabled with in-memory storage`
+2. Test your API endpoints to ensure they're working
+3. Your dashboard and tracker should now be functional
+
+## Monitoring
+
+- Monitor your Redis instance usage in the Render dashboard
+- Consider upgrading from the free Redis tier to a paid tier for production workloads
+- Set up alerts for Redis connection issues
+
+---
+
+The immediate fix has been applied, so your application should be working now. For long-term production use, consider implementing the proper Redis setup.

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --config gunicorn.conf.py application:application
+web: gunicorn -c gunicorn.conf.py application:application

--- a/backend/application.py
+++ b/backend/application.py
@@ -67,6 +67,11 @@ if ENABLE_RATE_LIMITING:
     # Configure Redis for rate limiting (fallback to memory if Redis not available)
     try:
         redis_url = os.environ.get('REDIS_URL', 'redis://localhost:6379')
+        # Test the Redis connection before using it
+        import redis
+        redis_client = redis.from_url(redis_url)
+        redis_client.ping()  # This will raise an exception if Redis is not available
+        
         limiter = Limiter(
             key_func=get_remote_address,
             app=application,

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,40 @@
+services:
+  # Redis/Key Value instance for rate limiting and caching
+  - type: redis
+    name: productivityflow-redis
+    ipAllowList: [] # only allow internal connections
+    plan: free # free tier for development, upgrade to starter for production
+    maxmemoryPolicy: allkeys-lru # good for caching use cases
+
+  # Main Flask web service
+  - type: web
+    name: productivityflow-backend-v3
+    runtime: python
+    buildCommand: "cd backend && pip install -r requirements.txt"
+    startCommand: "cd backend && gunicorn -c gunicorn.conf.py application:application"
+    healthCheckPath: "/health"
+    envVars:
+      - key: FLASK_ENV
+        value: production
+      - key: ENABLE_RATE_LIMITING
+        value: "true"
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: productivityflow-redis
+          property: connectionString
+      - key: SECRET_KEY
+        generateValue: true
+      - key: JWT_SECRET_KEY
+        generateValue: true
+      - key: ENCRYPTION_KEY
+        generateValue: true
+      # Add your other environment variables here
+      # - key: STRIPE_SECRET_KEY
+      #   sync: false
+      # - key: ANTHROPIC_API_KEY
+      #   sync: false
+      # - key: DATABASE_URL
+      #   fromDatabase:
+      #     name: your-database-name
+      #     property: connectionString


### PR DESCRIPTION
Fix Redis connection errors by adding in-memory fallback for rate limiting and providing a Render Blueprint for proper Redis setup.

The application was crashing with `redis.exceptions.ConnectionError: Error 111 connecting to localhost:6379. Connection refused.` because Flask-Limiter attempted to connect to a non-existent Redis instance on Render. This PR introduces a connection test and graceful fallback to in-memory storage, ensuring the application remains functional even without a Redis server. Additionally, a `render.yaml` is provided to easily provision a Redis instance for production environments.