### PR TITLE
Fix tauri config and dependency errors

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,7 +17,7 @@ Flask-Limiter==3.5.0
 # Security and Authentication
 bcrypt==4.1.2
 PyJWT==2.8.0
-cryptography==41.0.8
+cryptography==41.0.7
 
 # Environment and Configuration
 python-dotenv==1.0.0

--- a/employee-tracker-tauri/src-tauri/tauri.conf.json
+++ b/employee-tracker-tauri/src-tauri/tauri.conf.json
@@ -35,9 +35,6 @@
       "http": {
         "all": true,
         "request": true
-      },
-      "updater": {
-        "all": true
       }
     },
     "bundle": {

--- a/manager-dashboard-tauri/src-tauri/tauri.conf.json
+++ b/manager-dashboard-tauri/src-tauri/tauri.conf.json
@@ -35,9 +35,6 @@
       "http": {
         "all": true,
         "request": true
-      },
-      "updater": {
-        "all": true
       }
     },
     "bundle": {


### PR DESCRIPTION
Fix build failures by updating cryptography to an available version and correcting Tauri allowlist configuration.

The `cryptography` dependency was updated from `41.0.8` to `41.0.7` because `41.0.8` does not exist on PyPI, causing a `No matching distribution found` error. The `updater` property was removed from the `tauri > allowlist` section in both Tauri configuration files as it is not permitted there, which was causing `Additional properties are not allowed` errors during the build.